### PR TITLE
Retain original menu classes/ attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,3 +302,15 @@ If your menu is part of an auto-sized flex-child, it will probably need a positi
   flex-grow: 1;
 }
 ```
+
+### Navigation event listeners
+
+priorityPlus makes a copy of your menu, rather than reusing the original. Classes and attributes are carried over, but not event listeners. This means that any additional libraries or JavaScript which operate on the menu and its children needs to be run (or re-run) after initialization:
+
+```javascript
+priorityPlus(document.querySelector('.js-p-target'));
+// .js-p-target is *not* the same element, but has been cloned and replaced
+loadLibrary(document.querySelector('.js-p-target'));
+```
+
+If your use-case is not covered by this, please raise an issue.

--- a/cypress/integration/clonedMenu.ts
+++ b/cypress/integration/clonedMenu.ts
@@ -1,0 +1,71 @@
+import priorityPlus from '../../src/priorityPlus';
+
+describe('Cloned menu', () => {
+  it('should preserve the original menu\'s attributes', () => {
+    const original = document.createRange().createContextualFragment(`
+      <nav>
+        <ul class="menu-items test" data-depth="1" data-test>
+            <li class="menu-items__item menu-items__item_article menu-items__item_active" data-custom>
+              <a href="#">
+                Item One
+              </a>
+            </li>
+        </ul>
+      </nav>
+   `);
+
+    const [menu, items] = getMenuElements(original);
+
+    priorityPlus(menu);
+
+    const [instanceMenu, instanceItems] = getMenuElements(original);
+
+    assertEnhancedContainsAttributes(menu, instanceMenu);
+    assertEnhancedContainsClasses(menu, instanceMenu);
+
+    items.forEach((item, i) => {
+      assertEnhancedContainsAttributes(item, instanceItems[i]);
+      assertEnhancedContainsClasses(item, instanceItems[i]);
+    });
+  });
+});
+
+function getMenuElements(elem: DocumentFragment): [HTMLElement, HTMLLIElement[]] {
+  const menu = elem.querySelector('ul') as HTMLElement;
+  const items = Array.from(elem.querySelectorAll('li')) as HTMLLIElement[];
+  return [menu, items];
+}
+
+// Assert that each class on the original element is present on the copy.
+function assertEnhancedContainsClasses(original: HTMLElement, enhanced: HTMLElement) {
+  Array.from(original.classList).forEach(className => {
+    expect(Array.from(enhanced.classList), 'class').to.contain(className)
+  });
+}
+
+// Assert that every easily comparable attribute (e.g. not class) on the
+// original is present on the copy.
+function assertEnhancedContainsAttributes(original: HTMLElement, enhanced: HTMLElement) {
+  const [originalAttrs, enhancedAttrs] = [original, enhanced]
+    .map(getAttributes)
+    .map(retainComparable);
+  const originalDict = Object.fromEntries(originalAttrs);
+
+  // Filter out attributes added by priorityPlus.
+  const preserved = enhancedAttrs.filter(([key]) => key in originalDict);
+
+  expect(preserved, 'attributes').to.deep.equal(originalAttrs);
+}
+
+// Filter out hard to compare attributes.
+function retainComparable(attrList: string[][]) {
+  return attrList.filter(([name]) => name !== 'class');
+}
+
+function getAttributes(elem: HTMLElement) {
+  return Object.keys(elem.attributes).map(key => {
+    const attr = elem.attributes[Number(key)] as Attr;
+    return [attr.name, attr.value];
+  });
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "target": "es6",
     "lib": [
       "dom",
-      "es6"
+      "es2017"
     ]
   },
   "compileOnSave": false,


### PR DESCRIPTION
Previous iterations of the library used the original menu as a guide to
construct a clone. This resulted in any existing classes or attributes
not being carried over.

This PR clones the original menu directly, enhancing it with our
desired classes/data-attributes. Event listeners are not preserved due
to the cloning.